### PR TITLE
Removed invalid character in command to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ sudo apt-get install software-properties-common
 ```
 
 ```bash
-$ sudo add-apt-repository ppa:ondrej/apache2\
+$ sudo add-apt-repository ppa:ondrej/apache2
 ```
 
 ```bash


### PR DESCRIPTION
I stumbled upon this README and noticed this typo, some people might complain that it's not working ...